### PR TITLE
docs: modify documentation to reflect the use of Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ DeckTap uses `@nut-tree/nut-js` to simulate keyboard events. On macOS, you need 
 ## 🚀 Getting Started (LAN Mode)
 1. Install dependencies:
    ```bash
-   cd decktap-web && npm install && npm run build
+   cd decktap-web && npm install && vite build
    cd .. && npm install
    ```
 
@@ -75,7 +75,7 @@ DeckTap uses `@nut-tree/nut-js` to simulate keyboard events. On macOS, you need 
    - <img src="./images/computer-client.png" width="600">
    - Start controlling your presentation (Use 👉 to switch left and right hand mode)
    - <img src="./images/phone-controller.png" width="300" >
-  
+
 
 ---
 


### PR DESCRIPTION
- Updated the documentation to change the build command from `npm run build` to `vite build`.
- Ensured that the documentation  is consistent with the current build tool (Vite).
<img width="1164" height="515" alt="PixPin_2025-07-11_09-58-31" src="https://github.com/user-attachments/assets/4013088e-f887-4191-a550-ff224fced5af" />
